### PR TITLE
fix typo: event reference

### DIFF
--- a/client/lib/app.js
+++ b/client/lib/app.js
@@ -9,7 +9,7 @@ SuperCalendar = {
       });
     },
     onDayClick: function (e, t, data) {
-      var target = event;
+      var target = e;
       var date = data.date;
       var month = ('0' + (date.getMonth() + 1)).slice(-2);
       var day = ('0' + date.getDate()).slice(-2);
@@ -77,4 +77,3 @@ SuperCalendar = {
     });
   }
 };
-


### PR DESCRIPTION
Fix typo referencing the event object in `SuperCalendar.onDayClick`

issue: https://github.com/gabrielhpugliese/meteor_supercalendar/issues/13
